### PR TITLE
V1.1 - Tappable Titles and Constrained Accomodations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,18 @@
 # SwiftUI Tab Title Bar
-A SwiftUI view that contains an HStack of Text views and animates those views to large or small based on if their respective tab is active. 
+A SwiftUI view which will prominently display the currently selected tab title and present the user an option to change to another tab.
 
 This is a component that is initialized with a current index value and an array of Tab Items. Tab Items are a struct that contains a view and a target index. 
 
-Tab Item conforms to identifiable with a UUID predefined, however you can assign your own UUID should you so choose. 
+TabItem conforms to identifiable with a UUID predefined, however you can assign your own UUID should you so choose. 
 
-This is a component that was pulled out of my app Resolute to be shared as an open source package. Version 1.0 focuses on being a component built specifically for Resolute, however as time goes on I look forward to making it much more flexible. 
+This is a component that was pulled out of my app Resolute to be shared as an open source package. 
+
+# New in Version 1.1
+- The user can tap on the inactive tabs and that tab will be selected.
+- If the developer has more tabs than can fit in a horizontally constrained space, the view will collapse into a menu button which will display the currently selected title and on tap will open a menu picker to change the tab.
+
+# New Issues
+- I created an ItemWithModifier view with the intention to use it in the Menu style picker. But it appears the target index value never matches the currently selected tab. This is likely an easy fix, but at this time I'm going around in circles trying to fix it. When this is fixed, SingleTabTitleModifier can be deprecated.  
 
 # Demo
 <p align="center">
@@ -13,7 +20,7 @@ This is a component that was pulled out of my app Resolute to be shared as an op
 </p>
 
 # Scope
-- Ultimately, this is a list of items in an HStack.
+- Ultimately, this is a list of items in either an HStack or a Menu.
 - The currentTabSelection a `Binding<Int>`
 - TabItem contains the following.
     - An index, this is used to determine if the view is currently selected. 
@@ -21,24 +28,102 @@ This is a component that was pulled out of my app Resolute to be shared as an op
 - The states as of 1.0 are defined as follows.
     - Active: Font Size of 24 with a foreground color of .primary.
     - Inactive: Font Size of 12 with a foreground color of .secondary.
+- When the Menu style TabTitleBar is presented, you can change the following.
+    - changeTabLabel: 
+        - This is used on the Menu button to guide the user to tap here to change the tab. 
+        - This is a String value with a default value of "Change Tab". 
+    - changeTabSymbol:
+        - This is the icon used on the Menu button, this is an SF Symbol.
+        - This is a String value with a default value of "arrow.left.arrow.right.square"
 
-# Usage Example
+
+# Simple Usage Example
 ```
 struct ExampleView: View {
     @State var tabSelection: Int = 0
     
-    var tabItems: [TabItem] {
-        let item1 = TabItem(view: Text("Item 1"), index: 0)
-        let item2 = TabItem(view: Text("Item 2"), index: 1)
-        let item3 = TabItem(view: Text("Item 3"), index: 2)
-        
-        return [item1, item2, item3]
-    }
+    var tabItems: [TabItem] = Array(0...2).map({TabItem(view: Text("Item \($0)"), index: $0)})
     
     var body: some View {
         TabTitleBar(
             currentTabSelection: $tabSelection,
             tabItems: tabItems
+        )
+    }
+}
+```
+
+# Large Usage Example
+```
+struct ExampleView: View {
+    @State var tabSelection: Int = 0
+    
+    var tabItems: [TabItem] = [
+        TabItem(
+            view: Text("Shoes"),
+            index: 0
+        ),
+        TabItem(
+            view: Text("Workouts"),
+            index: 1
+        ),
+        TabItem(
+            view: Text("Recents"),
+            index: 2
+        ),
+        TabItem(
+            view: Text("Equipment"),
+            index: 3
+        ),
+        TabItem(
+            view: Text("Routing"),
+            index: 4
+        ),
+        TabItem(
+            view: Text("Replacements"),
+            index: 5
+        ),
+        TabItem(
+            view: Text("Settings"),
+            index: 6
+        )
+    ]
+    
+    var body: some View {
+        TabTitleBar(
+            currentTabSelection: $tabSelection,
+            tabItems: tabItems
+        )
+    }
+}
+```
+
+# Complex Usage Example
+```
+struct ExampleView: View {
+    @State var tabSelection: Int = 0
+    
+    var tabItems: [TabItem] = [
+        TabItem(
+            view: Text("Long Text Here"),
+            index: 0
+        ),
+        TabItem(
+            view: Text("More Long Text Here"),
+            index: 1
+        ),
+        TabItem(
+            view: Text("This is supposed to break to a new line"),
+            index: 2
+        )
+    ]
+    
+    var body: some View {
+        TabTitleBar(
+            currentTabSelection: $tabSelection,
+            tabItems: tabItems,
+            changeTabLabel: "Switch Tab",
+            changeTabSymbol: "arrow.triangle.branch"
         )
     }
 }

--- a/Sources/TabTitleBar/SingleTabTitleModifier.swift
+++ b/Sources/TabTitleBar/SingleTabTitleModifier.swift
@@ -1,0 +1,21 @@
+//
+//  SingleTabTitleModifier.swift
+//
+//
+//  Created by Brett Koster on 6/21/24.
+//
+
+import SwiftUI
+
+/// Provides a ViewModifier for the larger menu style tab picker
+/// As of writing, this is supposed to match the active state of TabTitleModifier with the exception of foregroundStyle and onChange
+struct SingleTabTitleModifier: ViewModifier {
+    let activeFontsize: CGFloat = 24
+
+    func body(content: Content) -> some View {
+        content
+            .font(.system(size: activeFontsize))
+            .fontWeight(.bold)
+            .multilineTextAlignment(.leading)
+    }
+}

--- a/Sources/TabTitleBar/TabTitleBar.swift
+++ b/Sources/TabTitleBar/TabTitleBar.swift
@@ -3,41 +3,100 @@ import SwiftUI
 public struct TabTitleBar: View {
     @Binding var currentTabSelection: Int
     let tabItems: [TabItem]
-    
+    let changeTabLabel: String
+    let changeTabSymbol: String
     
     /// An HStack that animates between the currently selected item and the next selected item
     /// - Parameters:
     ///   - currentTabSelection: Binding<Int> that will determine which item is active / inactive
     ///   - tabItems: An Array of TabItems, an Object that
-    public init(currentTabSelection: Binding<Int>, tabItems: [TabItem]) {
+    ///   - changeTabLabel: a String value which will be populated next to the changeTabSymbol
+    ///   - changeTabSymbol: a String value which should correpond to an SF Symbol
+    public init(
+        currentTabSelection: Binding<Int>,
+        tabItems: [TabItem],
+        changeTabLabel: String = "Change Tab",
+        changeTabSymbol: String = "arrow.left.arrow.right.square"
+    ) {
         _currentTabSelection = currentTabSelection
         self.tabItems = tabItems
+        self.changeTabLabel = changeTabLabel
+        self.changeTabSymbol = changeTabSymbol
     }
     
-    public var body: some View {
-        HStack {
-            ForEach(tabItems) { item in
-                item.view
-                    .modifier(TabTitleModifier(currentTabSelection: $currentTabSelection, targetIndex: item.index))
+    // Shared View to use on multiple sizes
+    @ViewBuilder
+    /// Loops through all TabItems and creates a  styled button for each
+    /// - Parameter withSelectionIndicator: Bool with a default value of false. Will show a checkmark when item is currently selected
+    /// - Returns: Button Subviews created with each TabItem
+    public func ButtonLoopView(withSelectionIndicator: Bool = false) -> some View {
+        ForEach(tabItems) { item in
+            Button {
+                withAnimation {
+                    currentTabSelection = item.index
+                }
+            } label: {
+                // For use in a Menu view (or another view else like it)
+                if withSelectionIndicator {
+                    Label {
+                        ItemWithModifer(item: item)
+                    } icon: {
+                        let isSelected = item.index == currentTabSelection
+                        Image(systemName: isSelected ? "checkmark" : "")
+                            .accessibilityHidden(true)
+                            .accessibilityHint(isSelected ? "Active Tab" : "")
+                    }
+                } else {
+                    // Default view for smaller views
+                    ItemWithModifer(item: item)
+                }
             }
+            // Set the color to primary so that the default blue button isn't used
+            .foregroundStyle(.primary)
+        }
+    }
+    
+    @ViewBuilder
+    public func ItemWithModifer(item: TabItem) -> some View {
+        item.view
+            .modifier(TabTitleModifier(
+                currentTabSelection: $currentTabSelection,
+                index: item.index)
+            )
+    }
+            
+    public var body: some View {
+        ViewThatFits(in: .horizontal) {
+            // By default the view does not scroll
+            HStack {
+                ButtonLoopView()
+            }
+            
+            // When the too many tabs are present, the title will collapse into a menu
+            Menu {
+                ButtonLoopView(withSelectionIndicator: true)
+            } label: {
+                HStack {
+                    tabItems[currentTabSelection].view
+                        .modifier(SingleTabTitleModifier())
+                        .foregroundStyle(.foreground)
+                    
+                    Spacer()
+                    
+                    Label(changeTabLabel, systemImage: "arrow.left.arrow.right.square")
+                }
+            }
+            .environment(\.menuOrder, .fixed)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .accessibilityHint("Tap here to change the active view")
         }
     }
 }
 
-#Preview {
-    ExampleView()
-}
-
-struct ExampleView: View {
+struct SmallExampleView: View {
     @State var tabSelection: Int = 0
     
-    var tabItems: [TabItem] {
-        let item1 = TabItem(view: Text("Item 1"), index: 0)
-        let item2 = TabItem(view: Text("Item 2"), index: 1)
-        let item3 = TabItem(view: Text("Item 3"), index: 2)
-        
-        return [item1, item2, item3]
-    }
+    var tabItems: [TabItem] = Array(0...2).map({TabItem(view: Text("Item \($0)"), index: $0)})
     
     var body: some View {
         VStack {
@@ -45,23 +104,88 @@ struct ExampleView: View {
                 currentTabSelection: $tabSelection,
                 tabItems: tabItems
             )
-            
-            HStack {
-                Button("1") {
-                    tabSelection = 0
-                }
-                .buttonStyle(.borderedProminent)
-                
-                Button("2") {
-                    tabSelection = 1
-                }
-                .buttonStyle(.borderedProminent)
-                
-                Button("3") {
-                    tabSelection = 2
-                }
-                .buttonStyle(.borderedProminent)
-            }
         }
     }
+}
+
+struct LargeExampleView: View {
+    @State var tabSelection: Int = 0
+    
+    var tabItems: [TabItem] = [
+        TabItem(
+            view: Text("Shoes"),
+            index: 0
+        ),
+        TabItem(
+            view: Text("Workouts"),
+            index: 1
+        ),
+        TabItem(
+            view: Text("Recents"),
+            index: 2
+        ),
+        TabItem(
+            view: Text("Equipment"),
+            index: 3
+        ),
+        TabItem(
+            view: Text("Routing"),
+            index: 4
+        ),
+        TabItem(
+            view: Text("Replacements"),
+            index: 5
+        ),
+        TabItem(
+            view: Text("Settings"),
+            index: 6
+        )
+    ]
+    
+    var body: some View {
+        TabTitleBar(
+            currentTabSelection: $tabSelection,
+            tabItems: tabItems
+        )
+    }
+}
+
+struct VeryLargeExampleView: View {
+    @State var tabSelection: Int = 0
+    
+    var tabItems: [TabItem] = [
+        TabItem(
+            view: Text("Long Text Here"),
+            index: 0
+        ),
+        TabItem(
+            view: Text("More Long Text Here"),
+            index: 1
+        ),
+        TabItem(
+            view: Text("This is supposed to break to a new line"),
+            index: 2
+        )
+    ]
+    
+    var body: some View {
+        TabTitleBar(
+            currentTabSelection: $tabSelection,
+            tabItems: tabItems,
+            changeTabLabel: "Switch Tab",
+            changeTabSymbol: "arrow.triangle.branch"
+        )
+    }
+}
+
+#Preview("Small") {
+    SmallExampleView()
+}
+
+#Preview("Large") {
+    LargeExampleView()
+}
+
+#Preview("VeryLarge") {
+    VeryLargeExampleView()
 }

--- a/Sources/TabTitleBar/TabTitleModifier.swift
+++ b/Sources/TabTitleBar/TabTitleModifier.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct TabTitleModifier: ViewModifier {
     @Binding var currentTabSelection: Int
-    let targetIndex: Int
+    let index: Int
    
     // Font size is used to reduce variables being changed... there is an issue where the baseline is shifting.
     // TODO: Once this issue is resolved, re-evaluate if you can use Apple's font size options
@@ -23,10 +23,10 @@ struct TabTitleModifier: ViewModifier {
     /// A view modifier that will stylize the tab item as either active or inactive
     /// - Parameters:
     ///   - currentTabSelection: a Binding<Int> that is the currently selected Tab
-    ///   - targetIndex: an Int to compare to currentTabSelection to determine if this item is active or inactive
-    init(currentTabSelection: Binding<Int>, targetIndex: Int) {
+    ///   - index: an Int to compare to currentTabSelection to determine if this item is active or inactive
+    init(currentTabSelection: Binding<Int>, index: Int) {
         _currentTabSelection = currentTabSelection
-        self.targetIndex = targetIndex
+        self.index = index
        
         _fontSize = State(wrappedValue: isActive() ? activeFontsize : inactiveFontsize)
         _foreground = State(wrappedValue: isActive() ? .primary : .secondary)
@@ -44,7 +44,7 @@ struct TabTitleModifier: ViewModifier {
    
     // Convenience to determine if this tab is active or inactive
     func isActive() -> Bool {
-        currentTabSelection == targetIndex
+        currentTabSelection == index
     }
    
     // Call this method to switch properties between active and inactive
@@ -57,3 +57,5 @@ struct TabTitleModifier: ViewModifier {
         }
     }
 }
+
+


### PR DESCRIPTION
Added
- changeTabLabel
- changeTabSymbol
- LargeExampleView
- VeryLargeExampleView

Removed
- Buttons from SmallExampleView

Enhancements
- Added a ViewThatFits(in: .horizontal) to split between an HStack and a Menu based on how many views need to be rendered
- Created ItemWithModifier to be reused whenever a TabItem.view needs to be rendered
- Created ButtonLoopView so that buttons can be rendered with one component instead of several

Simplified
- SmallExampleView tabItem initialization