### PR TITLE
Optional symbol

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ This is a component that was pulled out of my app Resolute to be shared as an op
 - The user can tap on the inactive tabs and that tab will be selected.
 - If the developer has more tabs than can fit in a horizontally constrained space, the view will collapse into a menu button which will display the currently selected title and on tap will open a menu picker to change the tab.
 
+# New in Version 1.2
+- The developer can now add an SF Symbol next to the text view. The title will then be a SwiftUI Label object. Symbol is an optional value on TabItem.  
+
 # New Issues
 - I created an ItemWithModifier view with the intention to use it in the Menu style picker. But it appears the target index value never matches the currently selected tab. This is likely an easy fix, but at this time I'm going around in circles trying to fix it. When this is fixed, SingleTabTitleModifier can be deprecated.  
 
@@ -38,22 +41,31 @@ This is a component that was pulled out of my app Resolute to be shared as an op
 
 
 # Simple Usage Example
+This will result in all Titles being visable and you can tab each title to change the tab
 ```
 struct ExampleView: View {
     @State var tabSelection: Int = 0
     
-    var tabItems: [TabItem] = Array(0...2).map({TabItem(view: Text("Item \($0)"), index: $0)})
+    var tabItems: [TabItem] = Array(0...2).map({
+        TabItem(
+            view: Text("Item \($0)"), 
+            index: $0,
+            symbol: "$0.circle"
+        )
+    })
     
     var body: some View {
         TabTitleBar(
             currentTabSelection: $tabSelection,
-            tabItems: tabItems
+            tabItems: tabItems,
+            symbol: "\($0).circle"
         )
     }
 }
 ```
 
 # Large Usage Example
+This will result in a the Tab Title to the left and a change tab Menu button to the right. 
 ```
 struct ExampleView: View {
     @State var tabSelection: Int = 0
@@ -99,6 +111,9 @@ struct ExampleView: View {
 ```
 
 # Complex Usage Example
+This will result in a the Tab Title to the left and a change tab Menu button to the right. 
+- This example will have symbols with the exception of the center item.
+- This will also demonstrate that if you have a very long tab title, it will break to a new line.
 ```
 struct ExampleView: View {
     @State var tabSelection: Int = 0
@@ -106,15 +121,18 @@ struct ExampleView: View {
     var tabItems: [TabItem] = [
         TabItem(
             view: Text("Long Text Here"),
-            index: 0
+            index: 0,
+            symbol: "circle.dashed"
         ),
         TabItem(
             view: Text("More Long Text Here"),
             index: 1
+            // It is valid to not define a symbol. If you do not define a symbol, a Text view will be rendered. 
         ),
         TabItem(
             view: Text("This is supposed to break to a new line"),
-            index: 2
+            index: 2,
+            symbol: "circle.hexagongrid"
         )
     ]
     

--- a/Sources/TabTitleBar/TabItem.swift
+++ b/Sources/TabTitleBar/TabItem.swift
@@ -12,11 +12,24 @@ import SwiftUI
 public struct TabItem: Identifiable {
     public let id: UUID
     public let view: Text
+    public let symbol: String?
     public let index: Int
     
-    public init(id: UUID = UUID(), view: Text, index: Int) {
+    /// Initializer with all parameters
+    /// - Parameters:
+    ///   - id: UUID for Identifiable conformance. UUID() is the default, you can also define your own
+    ///   - view: Text() view that will display on the title and in the picker
+    ///   - index: Int the target index to determine if this TabItem is selected or not
+    ///   - symbol: String? with a default value of nil. When defined, a Label with the view and symbol will be generated
+    public init(
+        id: UUID = UUID(),
+        view: Text,
+        index: Int,
+        symbol: String? = nil
+    ) {
         self.id = id
         self.view = view
         self.index = index
+        self.symbol = symbol
     }
 }

--- a/Sources/TabTitleBar/TabTitleBar.swift
+++ b/Sources/TabTitleBar/TabTitleBar.swift
@@ -39,7 +39,11 @@ public struct TabTitleBar: View {
                 // For use in a Menu view (or another view else like it)
                 if withSelectionIndicator {
                     Label {
-                        ItemWithModifer(item: item)
+                        ItemBuilder(item: item)
+                            .modifier(TabTitleModifier(
+                                currentTabSelection: $currentTabSelection,
+                                index: item.index)
+                            )
                     } icon: {
                         let isSelected = item.index == currentTabSelection
                         Image(systemName: isSelected ? "checkmark" : "")
@@ -48,7 +52,11 @@ public struct TabTitleBar: View {
                     }
                 } else {
                     // Default view for smaller views
-                    ItemWithModifer(item: item)
+                    ItemBuilder(item: item)
+                        .modifier(TabTitleModifier(
+                            currentTabSelection: $currentTabSelection,
+                            index: item.index)
+                        )
                 }
             }
             // Set the color to primary so that the default blue button isn't used
@@ -57,12 +65,18 @@ public struct TabTitleBar: View {
     }
     
     @ViewBuilder
-    public func ItemWithModifer(item: TabItem) -> some View {
-        item.view
-            .modifier(TabTitleModifier(
-                currentTabSelection: $currentTabSelection,
-                index: item.index)
-            )
+    public func ItemBuilder(item: TabItem) -> some View {
+        Group {
+            if let symbol = item.symbol {
+                Label(
+                    title: { item.view },
+                    icon: { Image(systemName: symbol) }
+                )
+                
+            } else {
+                item.view
+            }
+        }
     }
             
     public var body: some View {
@@ -77,7 +91,7 @@ public struct TabTitleBar: View {
                 ButtonLoopView(withSelectionIndicator: true)
             } label: {
                 HStack {
-                    tabItems[currentTabSelection].view
+                    ItemBuilder(item: tabItems[currentTabSelection])
                         .modifier(SingleTabTitleModifier())
                         .foregroundStyle(.foreground)
                     
@@ -96,7 +110,13 @@ public struct TabTitleBar: View {
 struct SmallExampleView: View {
     @State var tabSelection: Int = 0
     
-    var tabItems: [TabItem] = Array(0...2).map({TabItem(view: Text("Item \($0)"), index: $0)})
+    var tabItems: [TabItem] = Array(0...2).map({
+        TabItem(
+            view: Text("Item \($0)"),
+            index: $0,
+            symbol: "\($0).circle"
+        )
+    })
     
     var body: some View {
         VStack {
@@ -156,15 +176,18 @@ struct VeryLargeExampleView: View {
     var tabItems: [TabItem] = [
         TabItem(
             view: Text("Long Text Here"),
-            index: 0
+            index: 0,
+            symbol: "circle.dashed"
         ),
         TabItem(
             view: Text("More Long Text Here"),
-            index: 1
+            index: 1,
+            symbol: "circle.hexagonpath"
         ),
         TabItem(
             view: Text("This is supposed to break to a new line"),
-            index: 2
+            index: 2,
+            symbol: "circle.hexagongrid"
         )
     ]
     

--- a/Sources/TabTitleBar/TabTitleBar.swift
+++ b/Sources/TabTitleBar/TabTitleBar.swift
@@ -181,8 +181,7 @@ struct VeryLargeExampleView: View {
         ),
         TabItem(
             view: Text("More Long Text Here"),
-            index: 1,
-            symbol: "circle.hexagonpath"
+            index: 1
         ),
         TabItem(
             view: Text("This is supposed to break to a new line"),


### PR DESCRIPTION
Added the ability to optionally define an sf symbol to display next to the Title. 

The symbol is nil by default. If the developer does not define a symbol, the Text view will be rendered. If the developer does define a symbol, that Text view will be added into a Label view along with the defined symbol. 